### PR TITLE
Fix race condition problem

### DIFF
--- a/ansible/roles/domain-controller/tasks/main.yml
+++ b/ansible/roles/domain-controller/tasks/main.yml
@@ -22,16 +22,19 @@
     RetryCount: 100
     RetryIntervalSec: 10
   when: packer is not defined # TODO
+  tags: init
 
 - name: Set a weak password policy
   win_command: powershell.exe -
   args:
     stdin: "Set-ADDefaultDomainPasswordPolicy -MinPasswordLength 1 -ComplexityEnabled $False -Identity {{ domain.dns_name }}"
+  tags: init
 
 - name: Set domain root path (e.g. DC=xtof,DC=lab)
   set_fact:
     # e.g. DC=xtof,DC=lab
     domain_root_path: DC={{ domain.dns_name.split('.') | join(',DC=') }}
+  tags: init
 
 - name: Ensure OUs exist
   win_dsc:
@@ -40,6 +43,7 @@
     Path: "{{ item.split(',') | reject('search', item.split(',')[0]) | map('regex_replace', '(.+)', '\\1,') | join('') }}{{ domain_root_path }}"
     ProtectedFromAccidentalDeletion: no
   with_items: "{{ domain.organizational_units }}"
+  tags: init
 
 - name: Ensure domain groups exist
   win_domain_group:
@@ -48,6 +52,7 @@
     scope: global
     state: present
   with_items: "{{ domain.groups }}"
+  tags: init
 
 - name: Ensure domain users exist
   win_domain_user:
@@ -56,9 +61,11 @@
     path: "{{ item.OU | default('CN=Users') }},{{ domain_root_path }}"
     enabled: yes
   with_items: "{{ domain.users }}"
+  tags: init
 
 - name: Group memberships
   win_domain_group_membership:
     name: "{{ item.dn }},{{ domain_root_path }}"
     members: "{{ item.members }}"
   with_items: "{{ domain.groups }}"
+  tags: init

--- a/terraform/domain_controller.tf
+++ b/terraform/domain_controller.tf
@@ -62,6 +62,11 @@ resource "azurerm_virtual_machine" "dc" {
     command = "/bin/bash -c 'source venv/bin/activate && ansible-playbook domain-controllers.yml --tags=common,base -v'"
   }
 
+  provisioner "local-exec" {
+    working_dir = "${path.root}/../ansible"
+    command = "/bin/bash -c 'source venv/bin/activate && ansible-playbook domain-controllers.yml --tags=common,init -v'"
+  }
+
   tags = {
     kind = "domain-controller"
   }
@@ -71,8 +76,11 @@ resource "azurerm_virtual_machine" "dc" {
 resource "null_resource" "provision_rest_of_dc_after_creation" {
   provisioner "local-exec" {
     working_dir = "${path.root}/../ansible"
-    command = "/bin/bash -c 'source venv/bin/activate && ansible-playbook domain-controllers.yml --skip-tags=base -v'"
+    command = "/bin/bash -c 'source venv/bin/activate && ansible-playbook domain-controllers.yml --skip-tags=base,init -v'"
   }
 
-  depends_on = [azurerm_virtual_machine.dc]
+  depends_on = [
+    azurerm_virtual_machine.dc,
+    azurerm_virtual_machine.es_kibana
+  ]
 }


### PR DESCRIPTION
The Winlogbeat running on DC depends on the Elasticsearch server. However, the creation time sequence of DC and Elasticsearch is uncontrollable. The error occurs when DC tries to fetch the Elasticsearch server's private IP before the Elasticsearch server finishes its creation. And it will raise the error shown below:

```
null_resource.provision_rest_of_dc_after_creation (local-exec): TASK [winlogbeat : Find Elasticsearch IP] **************************************
null_resource.provision_rest_of_dc_after_creation (local-exec): fatal: [domain-controller_2a61]: FAILED! => {"msg": "The task includes an option with an undefined variable. The error was: 'dict object' has no attribute 'elasticsearch'\n\nThe error appears to be in 'Adaz/ansible/roles/winlogbeat/tasks/main.yml': line 8, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n- name: Find Elasticsearch IP\n  ^ here\n"}
```


In addition, the creation of the workstation also depends on DC. The user account must be already created on DC before starting the creation of the workstation. Otherwise, it will raise the error when doing the task "Ensure domain users can RDP on any workstation".