### PR TITLE
Update DC disk name

### DIFF
--- a/terraform/domain_controller.tf
+++ b/terraform/domain_controller.tf
@@ -38,7 +38,7 @@ resource "azurerm_virtual_machine" "dc" {
     version   = "latest"
   }
   storage_os_disk {
-    name              = "os-disk"
+    name              = "dc-disk"
     caching           = "ReadWrite"
     create_option     = "FromImage"
     managed_disk_type = "Standard_LRS"


### PR DESCRIPTION
os-disk is not obvious about which "os" it is. Kibana VM and workstations have an explicit name.  So DC should also to clear up things