### PR TITLE
add warning to vars.tf

### DIFF
--- a/terraform/vars.tf
+++ b/terraform/vars.tf
@@ -31,6 +31,7 @@ variable "region" {
 
 variable "resource_group" {
   # Warning: see https://github.com/christophetd/adaz/blob/master/doc/faq.md#how-to-change-the-name-of-the-resource-group-in-which-resources-are-created
+  # Warning: if you change this, also change it in ansible/inventory_azure_rm.yml
   description = "Resource group in which resources should be created. Will automatically be created and should not exist prior to running Terraform"
   default     = "ad-hunting-lab"
 }


### PR DESCRIPTION
When changing resource_group default, ansible inventory_azure_rm.yml must be updated as name is hardcoded inside too.